### PR TITLE
Drivers and rules auto-registration system with importlib

### DIFF
--- a/core.py
+++ b/core.py
@@ -145,7 +145,7 @@ class Judge:
         return (final_verdict, rules_broken)
 
 
-class IvoryDriver:
+class Driver:
     """
     A dummy Ivory driver to derive your own custom drivers from.
 

--- a/core.py
+++ b/core.py
@@ -145,7 +145,7 @@ class Judge:
         return (final_verdict, rules_broken)
 
 
-class Driver:
+class IvoryDriver:
     """
     A dummy Ivory driver to derive your own custom drivers from.
 

--- a/drivers/browser.py
+++ b/drivers/browser.py
@@ -12,18 +12,18 @@ from selenium.webdriver.support import expected_conditions as EC
 # NoElementFoundException, which we use to handle some potential fault areas
 from selenium.common.exceptions import NoSuchElementException
 # Ivory imports
-from core import Report, IvoryDriver, User
+from core import Report, Driver, User
 
 # Default timeout for the Selenium driver to get a Web page.
 DEFAULT_TIMEOUT = 30
 
-class Driver(IvoryDriver):
+class BrowserDriver(Driver):
     """
     A Selenium-based browser driver for Ivory.
     """
 
     def __init__(self, config):
-        IvoryDriver.__init__(self)
+        Driver.__init__(self)
         try:
             self.instance_url = config['instance_url']
         except KeyError:
@@ -188,3 +188,5 @@ class Driver(IvoryDriver):
         self.__wait.until(EC.title_contains('Perform moderation'))
         self.__driver.find_element_by_class_name('btn').click()
         self.__wait.until(EC.title_contains('Reports'))
+
+driver = BrowserDriver

--- a/drivers/browser.py
+++ b/drivers/browser.py
@@ -12,18 +12,18 @@ from selenium.webdriver.support import expected_conditions as EC
 # NoElementFoundException, which we use to handle some potential fault areas
 from selenium.common.exceptions import NoSuchElementException
 # Ivory imports
-from core import Report, Driver, User
+from core import Report, IvoryDriver, User
 
 # Default timeout for the Selenium driver to get a Web page.
 DEFAULT_TIMEOUT = 30
 
-class BrowserDriver(Driver):
+class Driver(IvoryDriver):
     """
     A Selenium-based browser driver for Ivory.
     """
 
     def __init__(self, config):
-        Driver.__init__(self)
+        IvoryDriver.__init__(self)
         try:
             self.instance_url = config['instance_url']
         except KeyError:

--- a/drivers/browser.py
+++ b/drivers/browser.py
@@ -80,16 +80,16 @@ class BrowserDriver(Driver):
         pwfield = self.__driver.find_element_by_id("user_password")
         pwfield.send_keys(password)
         pwfield.submit()
-        # Server needs a sec to catch up
-        self.__wait.until(EC.title_contains('Reports'))
         # OTP
         # TODO NON-OTP IS UNTESTED
         if otp:
+            # Server needs a sec to catch up
+            self.__wait.until(EC.presence_of_element_located((By.ID, 'user_otp_attempt')))
             otpfield = self.__driver.find_element_by_id('user_otp_attempt')
             otpfield.send_keys(otp)
             otpfield.submit()
-            # Server needs a sec to catch up
-            self.__wait.until(EC.url_contains('getting-started'))
+        # Server needs a sec to catch up
+        self.__wait.until(EC.url_contains('getting-started'))
         # Grab cookies
         cookies = self.__driver.get_cookies()
         return cookies

--- a/ivory.py
+++ b/ivory.py
@@ -40,20 +40,21 @@ class Ivory:
                 Rule = import_module('rules.' + rule_type).Rule
                 self.judge.add_rule(Rule(rule_config))
                 rulecount += 1
+            except ModuleNotFoundError:
+                print("ERROR: Rule #%d not found!" % rulecount)
             except Exception as err:
                 print("Failed to initialize rule #%d!" % rulecount)
                 raise err
         try:
             driver_config = config['driver']
-            try:
-                # programmatically load driver based on type in config
-                Driver = import_module('drivers.' + driver_config['type']).driver
-            except ImportError:
-                raise NotImplementedError()
+            # programmatically load driver based on type in config
+            Driver = import_module('drivers.' + driver_config['type']).driver
             self.driver = Driver(driver_config)
         except KeyError:
             print("ERROR: Driver configuration not found in config.yml!")
             exit(1)
+        except ModuleNotFoundError:
+            print("ERROR: Driver not found!")
         except Exception as err:
             print("ERROR: Failed to initialize driver!")
             raise err

--- a/ivory.py
+++ b/ivory.py
@@ -32,6 +32,7 @@ class Ivory:
             rules_config = config['rules']
         except KeyError:
             print("ERROR: Couldn't find any rules in config.yml!")
+            exit(1)
         rulecount = 1
         for rule_config in rules_config:
             try:
@@ -42,6 +43,7 @@ class Ivory:
                 rulecount += 1
             except ModuleNotFoundError:
                 print("ERROR: Rule #%d not found!" % rulecount)
+                exit(1)
             except Exception as err:
                 print("Failed to initialize rule #%d!" % rulecount)
                 raise err
@@ -55,6 +57,7 @@ class Ivory:
             exit(1)
         except ModuleNotFoundError:
             print("ERROR: Driver not found!")
+            exit(1)
         except Exception as err:
             print("ERROR: Failed to initialize driver!")
             raise err

--- a/ivory.py
+++ b/ivory.py
@@ -37,7 +37,7 @@ class Ivory:
             try:
                 # programmatically load rule based on type in config
                 rule_type = rule_config['type']
-                Rule = import_module('rules.' + rule_type).rule
+                Rule = import_module('rules.' + rule_type).Rule
                 self.judge.add_rule(Rule(rule_config))
                 rulecount += 1
             except Exception as err:
@@ -47,10 +47,10 @@ class Ivory:
             driver_config = config['driver']
             try:
                 # programmatically load driver based on type in config
-                driver = import_module('drivers.' + driver_config['type'])
+                Driver = import_module('drivers.' + driver_config['type']).driver
             except ImportError:
                 raise NotImplementedError()
-            self.driver = driver.Driver(driver_config)
+            self.driver = Driver(driver_config)
         except KeyError:
             print("ERROR: Driver configuration not found in config.yml!")
             exit(1)

--- a/rules/link_content.py
+++ b/rules/link_content.py
@@ -1,0 +1,21 @@
+import re
+from core import Rule, Report
+
+class LinkContentRule(Rule):
+    """
+    A rule which checks for banned link content.
+    """
+    def __init__(self, config):
+        Rule.__init__(self, config)
+        self.blocked = config['blocked']
+    def test(self, report: Report):
+        """
+        Test if a post's links matches any of the given blocked regexes.
+        """
+        for link in report.links:
+            for regex in self.blocked:
+                if re.search(regex, link):
+                    return True
+        return False
+
+rule = LinkContentRule

--- a/rules/link_resolver.py
+++ b/rules/link_resolver.py
@@ -1,0 +1,22 @@
+import re
+import requests
+from core import Rule, Report
+
+class LinkResolverRule(Rule):
+    """
+    A rule which checks for banned links, resolving links to prevent shorturl
+    mitigation.
+    """
+    def __init__(self, config):
+        Rule.__init__(self, config)
+        self.blocked = config['blocked']
+    def test(self, report: Report):
+        for link in report.links:
+            response = requests.head(link, allow_redirects=True)
+            resolved_url = response.url
+            for regex in self.blocked:
+                if re.search(regex, resolved_url):
+                    return True
+        return False
+
+rule = LinkResolverRule

--- a/rules/message_content.py
+++ b/rules/message_content.py
@@ -1,0 +1,19 @@
+import re
+
+from core import Rule, Report
+
+class MessageContentRule(Rule):
+    def __init__(self, config):
+        Rule.__init__(self, config)
+        self.blocked = config['blocked']
+    def test(self, report: Report):
+        """
+        Test if a post matches any of the given blocked regexes.
+        """
+        for post in report.posts:
+            for regex in self.blocked:
+                if re.search(regex, post):
+                    return True
+        return False
+
+rule = MessageContentRule

--- a/rules/username_content.py
+++ b/rules/username_content.py
@@ -1,0 +1,19 @@
+import re
+
+from core import Rule, Report
+
+class UsernameContentRule(Rule):
+    def __init__(self, config):
+        Rule.__init__(self, config)
+        self.blocked = config['blocked']
+    def test(self, report: Report):
+        """
+        Test if the reported user matches any of the blocked regexes."
+        """
+        username = report.reported.username
+        for regex in self.blocked:
+            if re.search(regex, username):
+                return True
+        return False
+
+rule = UsernameContentRule


### PR DESCRIPTION
This makes it so the user can dynamically import their driver and rules. Rules and drivers added to their respective folders and accessed with their filenames (i.e. setting `type: mycustomrule` when defining a rule will look for `rules/mycustomrule.py`). Maybe not the most elegant plugin solution, but it's simple and functional.

This comes with a change that breaks configs. Since file names now dictate the type, I've gone ahead and made things more specific on the way things are named. Example config needs to be updated to reflect this, but I'm tired and have work tomorrow.