### PR TITLE
Add test for signups without any invite_request text

### DIFF
--- a/rules/blank_signup.py
+++ b/rules/blank_signup.py
@@ -1,0 +1,18 @@
+import re
+
+from judge import Rule
+from schemas import PendingAcctRule
+
+class BlankSignupRule(Rule):
+    def __init__(self, raw_config):
+        config = PendingAcctRule(raw_config)
+        Rule.__init__(self, **config)
+    def test_pending_account(self, account: dict):
+        """
+        Test if a pending account's join reason is blank.
+        """
+        if not account.get('invite_request') or str(account.get('invite_request')) == "":
+            return True
+        return False
+
+rule = BlankSignupRule

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,28 @@ def pending_account(account):
         }
     return _pending_account
 
+@pytest.fixture
+def pending_account_no_invite(account):
+    def _pending_account_no_invite(**kwargs):
+        return {
+            "id": kwargs.get("account_id", "1"),
+            "username": kwargs.get("username", "fakeuser"),
+            "domain": None,
+            "created_at": "2019-01-01T00:00:00.000Z",
+            "email": kwargs.get("email", "testuser@example.com"),
+            "ip": kwargs.get("ip", "127.0.0.1"),
+            "role": "user",
+            "confirmed": True,
+            "suspended": False,
+            "silenced": False,
+            "disabled": False,
+            "approved": False,
+            "locale": "en",
+            "invite_request": None,
+            "account": account(**kwargs.get("account", {}))
+        }
+    return _pending_account_no_invite
+
 
 @pytest.fixture
 def admin_account(account):

--- a/tests/test_blank_signup.py
+++ b/tests/test_blank_signup.py
@@ -1,0 +1,32 @@
+import pytest
+import voluptuous
+from copy import deepcopy
+
+from rules.blank_signup import rule as Rule
+
+ruleconfig = {
+    "name": "Test rule",
+    "type": "test_type",
+    "severity": 1,
+    "punishment": {
+        "type": "reject"
+    }
+}
+
+
+@pytest.fixture
+def rule():
+    return Rule(ruleconfig)
+
+def test_evil_no_invite_pending_account(rule, pending_account_no_invite):
+    acct = pending_account_no_invite()
+    assert rule.test_pending_account(acct)
+
+def test_evil_pending_account(rule, pending_account):
+    acct2 = pending_account(message="")
+    assert rule.test_pending_account(acct2)
+
+def test_good_pending_account(rule, pending_account):
+    acct = pending_account(message="this seems like a nice instance!")
+    assert not rule.test_pending_account(acct)
+


### PR DESCRIPTION
Blank signups make up the bulk of spam account signups on my instance, so I thought a rule to block them made sense.